### PR TITLE
Update `grunt` in the `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
 	],
 	"main": "main.js",
 	"peerDependencies": {
-		"grunt": "~0.4.1"
+		"grunt": ">=0.4.1"
 	}
 }


### PR DESCRIPTION
https://github.com/gruntjs/grunt/blob/master/CHANGELOG
 - if you have a Grunt plugin that includes `grunt` in the `peerDependencies`, we recommend tagging with `"grunt": "">= 0.4.0"` and publishing a new version on npm.